### PR TITLE
Add GitHub Actions CI (build, lint, sqlx cache check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    env:
+      # The committed .sqlx cache lets the query macros typecheck without a database.
+      SQLX_OFFLINE: "true"
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --all-targets
+
+  lint:
+    name: lint (informational)
+    runs-on: ubuntu-latest
+    env:
+      SQLX_OFFLINE: "true"
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      # Non-blocking for now: surfaces formatting/lint drift as annotations
+      # without failing the build. Flip continue-on-error off once clean.
+      - run: cargo fmt --all --check
+        continue-on-error: true
+      - run: cargo clippy --all-targets
+        continue-on-error: true
+
+  sqlx-check:
+    name: sqlx cache up to date
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Apply the schema so the offline query cache can be validated against a real DB.
+      - run: psql "$DATABASE_URL" -f schema.sql
+      - run: cargo install sqlx-cli --no-default-features --features postgres,rustls --locked
+      # Fails if the committed .sqlx cache has drifted from the queries in the code.
+      - run: cargo sqlx prepare --check


### PR DESCRIPTION
First CI for this repo so we stop flying blind on breakage.

### What it does
- **`build`** (blocking): `cargo build --all-targets` on every push + PR, using the committed `.sqlx` offline cache (`SQLX_OFFLINE=true`) — no database needed.
- **`sqlx-check`** (blocking): spins up a Postgres service, applies `schema.sql`, and runs `cargo sqlx prepare --check`. Fails if the committed `.sqlx` cache has drifted from the queries in the code — the main footgun with offline sqlx.
- **`lint`** (informational, `continue-on-error`): `cargo fmt --all --check` + `cargo clippy --all-targets`. Non-blocking for now.

### Why lint is non-blocking
`cargo fmt --check` currently reports a diff here (rustfmt version drift on existing code, e.g. `src/jetstream/event.rs`). Rather than reformat your code in a CI PR, lint is informational; flip `continue-on-error` off once it's clean.

### Testing done
- `cargo build --all-targets` passes locally (Rust 1.94, `SQLX_OFFLINE=true`).
- The `sqlx-check` job should pass since the offline build already typechecks against the committed cache; if it ever goes red it's flagging real cache drift.