### PR TITLE
Clean clippy/rustfmt, make CI lint enforcing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - run: cargo build --all-targets
 
   lint:
-    name: lint (informational)
+    name: lint
     runs-on: ubuntu-latest
     env:
       SQLX_OFFLINE: "true"
@@ -35,12 +35,8 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
-      # Non-blocking for now: surfaces formatting/lint drift as annotations
-      # without failing the build. Flip continue-on-error off once clean.
       - run: cargo fmt --all --check
-        continue-on-error: true
-      - run: cargo clippy --all-targets
-        continue-on-error: true
+      - run: cargo clippy --all-targets -- -D warnings
 
   sqlx-check:
     name: sqlx cache up to date

--- a/src/jetstream/event.rs
+++ b/src/jetstream/event.rs
@@ -11,9 +11,15 @@ pub struct Event {
 #[derive(serde::Deserialize, Debug)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum EventKind {
-    Commit { commit: Commit },
-    Identity { identity: Identity },
-    Account { account: Account },
+    Commit {
+        commit: Commit,
+    },
+    Identity {
+        identity: Identity,
+    },
+    Account {
+        account: Account,
+    },
 
     #[serde(untagged)]
     Other(serde_json::Value),

--- a/src/jetstream/mod.rs
+++ b/src/jetstream/mod.rs
@@ -27,7 +27,7 @@ pub enum Error {
     Io(#[from] std::io::Error),
 }
 
-const ZSTD_DICTIONARY: std::sync::LazyLock<zstd::dict::DecoderDictionary<'static>> =
+static ZSTD_DICTIONARY: std::sync::LazyLock<zstd::dict::DecoderDictionary<'static>> =
     std::sync::LazyLock::new(|| {
         zstd::dict::DecoderDictionary::copy(include_bytes!("./zstd_dictionary"))
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ async fn fetch_events(
     reqwest_client: &reqwest::Client,
     events_url: &str,
 ) -> Result<std::collections::HashMap<String, AssociatedEvent>, anyhow::Error> {
-    Ok(reqwest_client
+    reqwest_client
         .get(events_url)
         .send()
         .await?
@@ -145,7 +145,7 @@ async fn fetch_events(
                 },
             ))
         })
-        .collect::<Result<_, _>>()?)
+        .collect::<Result<_, _>>()
 }
 
 const EXTRA_DATA_POST_RKEY: &str = "fbl_postRkey";
@@ -280,18 +280,15 @@ async fn sync_labels(
         })
         .collect::<std::collections::HashSet<atrium_api::types::string::RecordKey>>();
 
-    old_events = old_events
-        .into_iter()
-        .filter(|(_, oe)| {
-            if let Some(rkey) = oe.rkey.as_ref() {
-                if !record_rkeys.contains(rkey) {
-                    log::info!("could not find {}, will recreate", rkey.as_str());
-                    return false;
-                }
+    old_events.retain(|_, oe| {
+        if let Some(rkey) = oe.rkey.as_ref() {
+            if !record_rkeys.contains(rkey) {
+                log::info!("could not find {}, will recreate", rkey.as_str());
+                return false;
             }
-            true
-        })
-        .collect();
+        }
+        true
+    });
 
     // Delete old events if we don't see them in our retrieved events.
     for (label_id, oe) in old_events.into_iter() {
@@ -349,7 +346,7 @@ async fn sync_labels(
             assoc_event.rkey = Some(rkey.clone());
 
             {
-                let text = format!("{}", assoc_event.event.name);
+                let text = assoc_event.event.name.to_string();
 
                 let record: atrium_api::app::bsky::feed::post::Record =
                     atrium_api::app::bsky::feed::post::RecordData {
@@ -381,7 +378,7 @@ async fn sync_labels(
                             )],
                             index: atrium_api::app::bsky::richtext::facet::ByteSliceData {
                                 byte_start: 0,
-                                byte_end: text.bytes().len(),
+                                byte_end: text.len(),
                             }
                             .into(),
                         }
@@ -412,9 +409,9 @@ async fn sync_labels(
                         hidden_replies: None,
                         post: format!(
                             "at://{}/{}/{}",
-                            did.to_string(),
+                            did.as_str(),
                             atrium_api::app::bsky::feed::Post::NSID,
-                            rkey.to_string()
+                            rkey.as_str()
                         ),
                     }
                     .into();


### PR DESCRIPTION
Follow-up to #2 — flips the `lint` job from informational to blocking now that the warnings are cleared.

### Changes
- **rustfmt**: `src/jetstream/event.rs` reformatted (was the only drift).
- **clippy** (all safe, behavior-preserving):
  - `jetstream/mod.rs`: `const ZSTD_DICTIONARY` -> `static` (interior-mutability `LazyLock` should be a static).
  - `main.rs`: removed needless `Ok(...?)` wrap on `fetch_events`; `filter().collect()` -> `retain()`; `format!("{}", x)` -> `x.to_string()`; `text.bytes().len()` -> `text.len()`; `did.to_string()`/`rkey.to_string()` -> `did.as_str()`/`rkey.as_str()` in format args.
- `.github/workflows/ci.yml`: drop `continue-on-error` on fmt/clippy and add `-D warnings`.

### Testing done
Locally (Rust 1.94, `SQLX_OFFLINE=true`): `cargo fmt --all --check` clean, `cargo clippy --all-targets -- -D warnings` clean, `cargo build --all-targets` + `cargo test` pass. (Note: clippy's own suggestion of `**did` is a known false suggestion for Deref-to-str newtypes; used `.as_str()` which compiles.)